### PR TITLE
Add pitch to index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,9 +1,12 @@
 ---
+
 title: OWASP pytm
 layout: col-sidebar
 tags: threat-modeling threat modeling dataflow-diagram dataflow diagram python graphviz plantuml
 level: 3.5
 type: tool
+pitch: pytm is a Pythonic framework for threat modeling. The goal of pytm is to shift threat modeling to the left, making threat modeling more automated and developer-centric
+
 ---
 
 <style type="text/css">


### PR DESCRIPTION
The `pitch` is missing from the jekyll front-matter in the `index.md` file
This means that we have the entry 'More info soon...' for pytm in [OWASP Projects](https://owasp.org/projects/) page :

<img width="381" height="700" alt="Screenshot 2025-10-15 at 11 19 07" src="https://github.com/user-attachments/assets/61a57cbf-34e6-4cf3-ab23-c0ba2cc0caf4" />

This pull request corrects this
Closes #2 